### PR TITLE
Fix setup.py to refer to renamed README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_dir={'': 'src'},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
 
-    long_description=read('README.md'),
+    long_description=read('README.rst'),
     author='Amazon Web Services',
     url='https://github.com/aws/sagemaker-tensorflow-containers',
     license='Apache License 2.0',


### PR DESCRIPTION
Setup now works:

python setup.py sdist && pip install dist/sagemaker_tensorflow_container-1.0.0.tar.gz