### PR TITLE
Use regional endpoint for S3 client

### DIFF
--- a/src/tf_container/experiment_trainer.py
+++ b/src/tf_container/experiment_trainer.py
@@ -15,7 +15,7 @@ import boto3
 import inspect
 import os
 import tensorflow as tf
-from container_support import parse_s3_url
+import tf_container.s3_fs as s3_fs
 from tf_container.run import logger
 from tensorflow.contrib.learn import RunConfig, Experiment
 from tensorflow.contrib.learn.python.learn import learn_runner
@@ -73,7 +73,7 @@ class Trainer(object):
         self.customer_params = customer_params
 
         if model_path.startswith('s3://'):
-            self._configure_s3_file_system()
+            s3_fs.configure_s3_fs(model_path)
 
     def _get_task_type(self, masters):
         if self.current_host in masters:
@@ -263,18 +263,6 @@ class Trainer(object):
                 model_fn=_model_fn,
                 params=hyperparameters,
                 config=run_config)
-
-    def _configure_s3_file_system(self):
-        # loads S3 filesystem plugin
-        s3 = boto3.client('s3')
-
-        bucket_name, key = parse_s3_url(self.model_path)
-
-        bucket_location = s3.get_bucket_location(Bucket=bucket_name)['LocationConstraint']
-
-        if bucket_location:
-            os.environ['S3_REGION'] = bucket_location
-        os.environ['S3_USE_HTTPS'] = "1"
 
 
 def _function(object):

--- a/src/tf_container/s3_fs.py
+++ b/src/tf_container/s3_fs.py
@@ -1,5 +1,5 @@
-import boto3
 import os
+import boto3
 import container_support as cs
 
 
@@ -8,7 +8,7 @@ def configure_s3_fs(checkpoint_path):
     region_name = os.environ.get('AWS_REGION')
     s3 = boto3.client('s3', region_name=region_name)
 
-    # We get the aws region of the checkpoint bucket, which may be different from
+    # We get the AWS region of the checkpoint bucket, which may be different from
     # the region this container is currently running in.
     bucket_name, key = cs.parse_s3_url(checkpoint_path)
     bucket_location = s3.get_bucket_location(Bucket=bucket_name)['LocationConstraint']

--- a/src/tf_container/s3_fs.py
+++ b/src/tf_container/s3_fs.py
@@ -1,0 +1,19 @@
+import boto3
+import os
+import container_support as cs
+
+
+def configure_s3_fs(checkpoint_path):
+    # If env variable is not set, defaults to None, which will use the global endpoint.
+    region_name = os.environ.get('AWS_REGION')
+    s3 = boto3.client('s3', region_name=region_name)
+
+    # We get the aws region of the checkpoint bucket, which may be different from
+    # the region this container is currently running in.
+    bucket_name, key = cs.parse_s3_url(checkpoint_path)
+    bucket_location = s3.get_bucket_location(Bucket=bucket_name)['LocationConstraint']
+
+    # Configure environment variables used by TensorFlow S3 file system
+    if bucket_location:
+        os.environ['S3_REGION'] = bucket_location
+    os.environ['S3_USE_HTTPS'] = '1'

--- a/test/unit/test_experiment_trainer.py
+++ b/test/unit/test_experiment_trainer.py
@@ -112,12 +112,15 @@ def test_build_tf_config_with_multiple_hosts(trainer):
 @patch('botocore.session.get_session')
 @patch('os.environ')
 def test_configure_s3_file_system(os_env, botocore, boto_client, trainer):
+    region = os_env.get('AWS_REGION')
+
     trainer.Trainer(customer_script=mock_script,
                     current_host=current_host,
                     hosts=hosts,
                     model_path='s3://my/s3/path')
 
-    boto_client('s3').get_bucket_location.assert_called_once_with(Bucket='my')
+    boto_client.assert_called_once_with('s3', region_name=region)
+    boto_client('s3', region_name=region).get_bucket_location.assert_called_once_with(Bucket='my')
 
     calls = [
         call('S3_USE_HTTPS', '1'),

--- a/test/unit/test_trainer.py
+++ b/test/unit/test_trainer.py
@@ -341,12 +341,15 @@ def test_build_tf_config_with_multiple_hosts(trainer):
 @patch('botocore.session.get_session')
 @patch('os.environ')
 def test_configure_s3_file_system(os_env, botocore, boto_client, trainer_module):
+    region = os_env.get('AWS_REGION')
+
     trainer_module.Trainer(customer_script=MOCK_SCRIPT,
                            current_host=CURRENT_HOST,
                            hosts=HOSTS,
                            model_path='s3://my/s3/path')
 
-    boto_client('s3').get_bucket_location.assert_called_once_with(Bucket='my')
+    boto_client.assert_called_once_with('s3', region_name=region)
+    boto_client('s3', region_name=region).get_bucket_location.assert_called_once_with(Bucket='my')
 
     calls = [
         call('S3_USE_HTTPS', '1'),


### PR DESCRIPTION
Use the AWS region from the environment for the S3 endpoint, if defined.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
