### PR TITLE
Move processing of requirements file into train().

### DIFF
--- a/src/tf_container/train_entry_point.py
+++ b/src/tf_container/train_entry_point.py
@@ -114,6 +114,7 @@ def train():
     os.environ['S3_REQUEST_TIMEOUT_MSEC'] = str(env.hyperparameters.get('s3_checkpoint_save_timeout', 60000))
 
     env.download_user_module()
+    env.pip_install_requirements()
 
     customer_script = env.import_user_module()
 

--- a/test/integ/test_estimator_classification.py
+++ b/test/integ/test_estimator_classification.py
@@ -23,7 +23,6 @@ from test.integ.conftest import SCRIPT_PATH
 def test_estimator_classification(docker_image, sagemaker_session, opt_ml, processor):
     resource_path = os.path.join(SCRIPT_PATH, '../resources/iris')
 
-    copy_resource(resource_path, opt_ml, 'code')
     copy_resource(resource_path, opt_ml, 'data', 'input/data')
 
     s3_source_archive = fw_utils.tar_and_upload_dir(session=sagemaker_session.boto_session,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/issues/139

*Description of changes:*
The code to process the requirement file must happen after the code is downloaded. Adding invocation of the function.
Fixed the test so that they do not make code available via container mapped volumes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
