### PR TITLE
Checkout v1.4.1 tag instead of r1.4 branch

### DIFF
--- a/docker/1.4.1/base/Dockerfile.cpu
+++ b/docker/1.4.1/base/Dockerfile.cpu
@@ -57,7 +57,7 @@ RUN mkdir /bazel && \
 # Download TensorFlow.
 RUN git clone https://github.com/tensorflow/tensorflow.git && \
     cd tensorflow && \
-    git checkout r1.4
+    git checkout v1.4.1
 
 WORKDIR /tensorflow
 
@@ -85,7 +85,7 @@ WORKDIR /root
 
 # cleaning up the container
 RUN rm -rf /tensorflow && \
-    rm -rf /tmp/tensorflow_pkg/tensorflow-1.4.0-cp27-cp27mu-linux_x86_64.whl && \
+    rm -rf /tmp/tensorflow_pkg/tensorflow-1.4.1-cp27-cp27mu-linux_x86_64.whl && \
     rm -rf /bazel
 
 CMD ["/bin/bash"]

--- a/docker/1.4.1/base/Dockerfile.gpu
+++ b/docker/1.4.1/base/Dockerfile.gpu
@@ -65,7 +65,7 @@ RUN mkdir /bazel && \
 
 RUN git clone https://github.com/tensorflow/tensorflow.git && \
     cd tensorflow && \
-    git checkout r1.4
+    git checkout v1.4.1
 
 WORKDIR /tensorflow
 
@@ -133,7 +133,7 @@ WORKDIR /root
 # cleaning up the container
 RUN rm -rf /tensorflow && \
     rm -rf /serving && \
-    rm -rf /tmp/tensorflow_pkg/tensorflow-1.4.0-cp27-cp27mu-linux_x86_64.whl && \
+    rm -rf /tmp/tensorflow_pkg/tensorflow-1.4.1-cp27-cp27mu-linux_x86_64.whl && \
     rm -rf /bazel
 
 RUN ["/bin/bash"]


### PR DESCRIPTION
*Description of changes:*
New versions of our base images were failing tests because the `r1.4` branch of TensorFlow now points to v1.4.2. By checking out the version-specific tag, we ensure that we have the correct version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
