### PR TITLE
Fix hyperparameter name for detecting a tuning job

### DIFF
--- a/src/tf_container/train_entry_point.py
+++ b/src/tf_container/train_entry_point.py
@@ -111,7 +111,7 @@ def _get_checkpoint_dir(env):
     checkpoint_path = env.hyperparameters['checkpoint_path']
 
     # If this is not part of a tuning job, then we can just use the specified checkpoint path
-    if 'algorithms_tuning_objective_metric' not in env.hyperparameters:
+    if '_tuning_objective_metric' not in env.hyperparameters:
         return checkpoint_path
 
     job_name = env.job_name

--- a/test/unit/test_train_entry_point.py
+++ b/test/unit/test_train_entry_point.py
@@ -20,6 +20,7 @@ from test.unit.utils import mock_import_modules
 
 CHECKPOINT_PATH = 'customer/checkpoint/path'
 JOB_NAME = 'test-1234'
+TUNING_HYPERPARAMETER_NAME = '_tuning_objective_metric'
 TUNING_METRIC = 'some-metric'
 
 
@@ -70,7 +71,7 @@ def test_get_checkpoint_dir_with_job_name_in_path(train_entry_point_module):
     checkpoint_path_with_job_name = '{}/checkpoints'.format(JOB_NAME)
     hyperparameters = {
         'checkpoint_path': checkpoint_path_with_job_name,
-        'algorithms_tuning_objective_metric': TUNING_METRIC,
+        TUNING_HYPERPARAMETER_NAME: TUNING_METRIC,
     }
     env = Mock(name='env', hyperparameters=hyperparameters, job_name=JOB_NAME)
     checkpoint_dir = train_entry_point_module._get_checkpoint_dir(env)
@@ -81,7 +82,7 @@ def test_get_checkpoint_dir_with_job_name_in_path(train_entry_point_module):
 def test_get_checkpoint_dir_without_job_name_env(train_entry_point_module):
     hyperparameters = {
         'checkpoint_path': CHECKPOINT_PATH,
-        'algorithms_tuning_objective_metric': TUNING_METRIC,
+        TUNING_HYPERPARAMETER_NAME: TUNING_METRIC,
     }
     env = Mock(name='env', hyperparameters=hyperparameters, job_name=None)
     checkpoint_dir = train_entry_point_module._get_checkpoint_dir(env)
@@ -92,7 +93,7 @@ def test_get_checkpoint_dir_without_job_name_env(train_entry_point_module):
 def test_get_checkpoint_dir_appending_job_name(train_entry_point_module):
     hyperparameters = {
         'checkpoint_path': CHECKPOINT_PATH,
-        'algorithms_tuning_objective_metric': TUNING_METRIC,
+        TUNING_HYPERPARAMETER_NAME: TUNING_METRIC,
     }
     env = Mock(name='env', hyperparameters=hyperparameters, job_name=JOB_NAME)
     checkpoint_dir = train_entry_point_module._get_checkpoint_dir(env)


### PR DESCRIPTION
*Description of changes:*
I got the hyperparameter name wrong previously. This should fix it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
