### PR TITLE
Add Pillow to pip install list

### DIFF
--- a/docker/1.4.1/base/Dockerfile.cpu
+++ b/docker/1.4.1/base/Dockerfile.cpu
@@ -30,6 +30,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 # Set up Bazel.

--- a/docker/1.4.1/base/Dockerfile.gpu
+++ b/docker/1.4.1/base/Dockerfile.gpu
@@ -31,6 +31,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 # Set up grpc

--- a/docker/1.5.0/base/Dockerfile.cpu
+++ b/docker/1.5.0/base/Dockerfile.cpu
@@ -30,6 +30,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 # Set up Bazel.

--- a/docker/1.5.0/base/Dockerfile.gpu
+++ b/docker/1.5.0/base/Dockerfile.gpu
@@ -39,6 +39,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 # Set up grpc

--- a/docker/1.6.0/base/Dockerfile.cpu
+++ b/docker/1.6.0/base/Dockerfile.cpu
@@ -34,6 +34,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 WORKDIR /root
@@ -43,4 +44,3 @@ RUN pip install numpy boto3 six awscli flask==0.11 Jinja2==2.9 tensorflow-servin
 # install tensorflow-model-server 1.5. 1.6 is not working as of 3/29/2018 for unknown reasons.
 RUN wget 'http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server/t/tensorflow-model-server/tensorflow-model-server_1.5.0_all.deb' && \
     dpkg -i tensorflow-model-server_1.5.0_all.deb
-

--- a/docker/1.6.0/base/Dockerfile.gpu
+++ b/docker/1.6.0/base/Dockerfile.gpu
@@ -42,6 +42,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 RUN pip install numpy tensorflow-serving-api==1.5
@@ -108,4 +109,3 @@ RUN bazel build -c opt --config=cuda \
 # cleaning up the container
 RUN rm -rf /serving && \
     rm -rf /bazel
-

--- a/docker/1.7.0/base/Dockerfile.cpu
+++ b/docker/1.7.0/base/Dockerfile.cpu
@@ -34,6 +34,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 WORKDIR /root

--- a/docker/1.7.0/base/Dockerfile.gpu
+++ b/docker/1.7.0/base/Dockerfile.gpu
@@ -42,6 +42,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 # Set up grpc
@@ -114,4 +115,3 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
 # cleaning up the container
 RUN rm -rf /serving && \
     rm -rf /bazel
-

--- a/docker/1.8.0/base/Dockerfile.cpu
+++ b/docker/1.8.0/base/Dockerfile.cpu
@@ -34,6 +34,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 WORKDIR /root

--- a/docker/1.8.0/base/Dockerfile.gpu
+++ b/docker/1.8.0/base/Dockerfile.gpu
@@ -42,6 +42,7 @@ RUN pip --no-cache-dir install \
         scipy \
         sklearn \
         pandas \
+        Pillow \
         h5py
 
 # Set up grpc
@@ -116,4 +117,3 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
 # cleaning up the container
 RUN rm -rf /serving && \
     rm -rf /bazel
-


### PR DESCRIPTION
*Issue #, if available:*
aws/sagemaker-python-sdk#231

*Description of changes:*
Pillow needs to be imported before tensorflow to work with keras, like what we saw with h5py in aws/sagemaker-python-sdk#84

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
